### PR TITLE
[Feature] DANDAN 회원 가입 및 로그인 기능 구현 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ out/
 ### VS Code ###
 .vscode/
 src/main/resources/application-dev.yml
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 src/main/resources/application-dev.yml
 
 .DS_Store
+._.DS_Store
+**/.DS_Store
+**/._.DS_Store

--- a/src/main/java/com/se/dandan/controller/AuthController.java
+++ b/src/main/java/com/se/dandan/controller/AuthController.java
@@ -1,4 +1,45 @@
 package com.se.dandan.controller;
 
+import com.se.dandan.dto.IdCheckRequestDTO;
+import com.se.dandan.dto.SignInRequestDTO;
+import com.se.dandan.dto.SignUpRequestDTO;
+import com.se.dandan.dto.TokenInfo;
+import com.se.dandan.dto.common.ResponseTemplate;
+import com.se.dandan.service.AuthService;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
 public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/id-check")
+    public ResponseTemplate<?> idCheck(@RequestBody @Valid IdCheckRequestDTO idCheckRequestDTO) {
+        authService.idCheck(idCheckRequestDTO);
+        return new ResponseTemplate<>(HttpStatus.OK, "사용할 수 있는 아이디 입니다.");
+    }
+
+    @PostMapping("/sign-up")
+    public ResponseTemplate<?> signUp(@RequestBody @Valid SignUpRequestDTO signUpRequestDTO) {
+        authService.signUp(signUpRequestDTO);
+        return new ResponseTemplate<>(HttpStatus.OK, "회원가입 성공");
+    }
+
+    @PostMapping("/sign-in")
+    public ResponseTemplate<TokenInfo> signIn(@RequestBody @Valid SignInRequestDTO signInRequestDTO, HttpServletResponse response) {
+        TokenInfo token = authService.signIn(signInRequestDTO, response);
+
+        return new ResponseTemplate<>(HttpStatus.OK, "로그인 성공", token);
+    }
 }

--- a/src/main/java/com/se/dandan/controller/AuthController.java
+++ b/src/main/java/com/se/dandan/controller/AuthController.java
@@ -6,6 +6,10 @@ import com.se.dandan.dto.SignUpRequestDTO;
 import com.se.dandan.dto.TokenInfo;
 import com.se.dandan.dto.common.ResponseTemplate;
 import com.se.dandan.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Auth API", description = "회원가입 및 로그인 API")
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthController {
@@ -24,18 +29,30 @@ public class AuthController {
         this.authService = authService;
     }
 
+    @Operation(summary = "아이디 중복 확인 컨트롤러", description = "아이디 중복 확인을 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/id-check")
     public ResponseTemplate<?> idCheck(@RequestBody @Valid IdCheckRequestDTO idCheckRequestDTO) {
         authService.idCheck(idCheckRequestDTO);
         return new ResponseTemplate<>(HttpStatus.OK, "사용할 수 있는 아이디 입니다.");
     }
 
+    @Operation(summary = "회원가입 컨트롤러", description = "회원가입을 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/sign-up")
     public ResponseTemplate<?> signUp(@RequestBody @Valid SignUpRequestDTO signUpRequestDTO) {
         authService.signUp(signUpRequestDTO);
         return new ResponseTemplate<>(HttpStatus.OK, "회원가입 성공");
     }
 
+    @Operation(summary = "로그인 컨트롤러", description = "로그인을 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/sign-in")
     public ResponseTemplate<TokenInfo> signIn(@RequestBody @Valid SignInRequestDTO signInRequestDTO, HttpServletResponse response) {
         TokenInfo token = authService.signIn(signInRequestDTO, response);

--- a/src/main/java/com/se/dandan/controller/CheckController.java
+++ b/src/main/java/com/se/dandan/controller/CheckController.java
@@ -1,15 +1,25 @@
 package com.se.dandan.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Collections;
+import java.util.Map;
+
+@Tag(name = "Ping Check", description = "단순 서버 연결 상태 확인 API")
 @RestController
 @RequestMapping("/api/v1/check")
 public class CheckController {
 
+    @Operation(summary = "서버 상태 체크", description = "서버가 정상적으로 동작하는지 확인하는 API입니다.")
+    @ApiResponse(responseCode = "200", description = "서버 정상 작동. 응답: text/plain (pong)")
     @GetMapping("/ping")
-    public String ping() {
-        return "pong";
+    public ResponseEntity<Map<String, String>> ping() {
+        return ResponseEntity.ok(Collections.singletonMap("message", "pong"));
     }
 }

--- a/src/main/java/com/se/dandan/dto/IdCheckRequestDTO.java
+++ b/src/main/java/com/se/dandan/dto/IdCheckRequestDTO.java
@@ -1,0 +1,14 @@
+package com.se.dandan.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+@Data
+public class IdCheckRequestDTO {
+
+    @NotBlank
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]{7,15}$") // 영문자, 숫자를 포함한 7글자 이상 15글자 이하
+    private String userId;
+
+}

--- a/src/main/java/com/se/dandan/dto/IdCheckRequestDTO.java
+++ b/src/main/java/com/se/dandan/dto/IdCheckRequestDTO.java
@@ -1,12 +1,15 @@
 package com.se.dandan.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
+@Schema(description = "아이디 중복확인 DTO")
 @Data
 public class IdCheckRequestDTO {
 
+    @Schema(description = "사용자 아이디", example = "test123")
     @NotBlank
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]{7,15}$",
             message = "아이디는 영문자와 숫자를 포함하여 7자 이상 15자 이하로 입력해주세요.") // 영문자, 숫자를 포함한 7글자 이상 15글자 이하

--- a/src/main/java/com/se/dandan/dto/IdCheckRequestDTO.java
+++ b/src/main/java/com/se/dandan/dto/IdCheckRequestDTO.java
@@ -8,7 +8,8 @@ import lombok.Data;
 public class IdCheckRequestDTO {
 
     @NotBlank
-    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]{7,15}$") // 영문자, 숫자를 포함한 7글자 이상 15글자 이하
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]{7,15}$",
+            message = "아이디는 영문자와 숫자를 포함하여 7자 이상 15자 이하로 입력해주세요.") // 영문자, 숫자를 포함한 7글자 이상 15글자 이하
     private String userId;
 
 }

--- a/src/main/java/com/se/dandan/dto/SignInRequestDTO.java
+++ b/src/main/java/com/se/dandan/dto/SignInRequestDTO.java
@@ -1,4 +1,14 @@
 package com.se.dandan.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
 public class SignInRequestDTO {
+
+    @NotBlank
+    private String nickname;
+
+    @NotBlank
+    private String password;
 }

--- a/src/main/java/com/se/dandan/dto/SignInRequestDTO.java
+++ b/src/main/java/com/se/dandan/dto/SignInRequestDTO.java
@@ -7,7 +7,7 @@ import lombok.Data;
 public class SignInRequestDTO {
 
     @NotBlank
-    private String nickname;
+    private String userId;
 
     @NotBlank
     private String password;

--- a/src/main/java/com/se/dandan/dto/SignInRequestDTO.java
+++ b/src/main/java/com/se/dandan/dto/SignInRequestDTO.java
@@ -1,14 +1,18 @@
 package com.se.dandan.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
+@Schema(description = "로그인 DTO")
 @Data
 public class SignInRequestDTO {
 
+    @Schema(description = "사용자 아이디", example = "test123")
     @NotBlank
     private String userId;
 
+    @Schema(description = "사용자 비밀번호", example = "test123!")
     @NotBlank
     private String password;
 }

--- a/src/main/java/com/se/dandan/dto/SignUpRequestDTO.java
+++ b/src/main/java/com/se/dandan/dto/SignUpRequestDTO.java
@@ -20,4 +20,7 @@ public class SignUpRequestDTO {
 
     private String checkPassword;
 
+    @NotBlank
+    private int wordCount;
+
 }

--- a/src/main/java/com/se/dandan/dto/SignUpRequestDTO.java
+++ b/src/main/java/com/se/dandan/dto/SignUpRequestDTO.java
@@ -1,14 +1,17 @@
 package com.se.dandan.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
+@Schema(description = "회원가입 DTO")
 @Data
 public class SignUpRequestDTO {
 
+    @Schema(description = "사용자 이름", example = "홍길동")
     @NotBlank
     @Size(min = 4, max = 6, message = "닉네임은 4자 이상 6자 이하로 입력해주세요.")
     @Pattern(
@@ -17,18 +20,22 @@ public class SignUpRequestDTO {
     )
     private String nickname;
 
+    @Schema(description = "사용자 아이디", example = "test123")
     @NotBlank
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]{7,15}$",
             message = "아이디는 영문자와 숫자를 포함하여 7자 이상 15자 이하로 입력해주세요.")
     private String userId;
 
+    @Schema(description = "사용자 비밀번호", example = "test123!")
     @NotBlank
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+\\[\\]{};':\"\\\\|,.<>/?]).{8,}$",
             message = "비밀번호는 영문자, 숫자, 특수문자를 포함한 최소 8자 이상이어야 합니다.")
     private String password;
 
+    @Schema(description = "사용자 비밀번호 확인", example = "test123!")
     private String checkPassword;
 
+    @Schema(description = "목표 단어 개수 설정", example = "5")
     @NotNull
     private int wordCount;
 

--- a/src/main/java/com/se/dandan/dto/SignUpRequestDTO.java
+++ b/src/main/java/com/se/dandan/dto/SignUpRequestDTO.java
@@ -1,4 +1,23 @@
 package com.se.dandan.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+@Data
 public class SignUpRequestDTO {
+
+    @NotBlank
+    private String nickname;
+
+    @NotBlank
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]{7,15}$") // 영문자, 숫자를 포함한 7글자 이상 15글자 이하
+    private String userId;
+
+    @NotBlank
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@#$%^&+=!]).{8,}$") // 영문자, 특수문자, 숫자를 포함한 최소 8자 이상의 문자
+    private String password;
+
+    private String checkPassword;
+
 }

--- a/src/main/java/com/se/dandan/dto/SignUpRequestDTO.java
+++ b/src/main/java/com/se/dandan/dto/SignUpRequestDTO.java
@@ -1,6 +1,7 @@
 package com.se.dandan.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
@@ -20,7 +21,7 @@ public class SignUpRequestDTO {
 
     private String checkPassword;
 
-    @NotBlank
+    @NotNull
     private int wordCount;
 
 }

--- a/src/main/java/com/se/dandan/dto/SignUpRequestDTO.java
+++ b/src/main/java/com/se/dandan/dto/SignUpRequestDTO.java
@@ -3,20 +3,28 @@ package com.se.dandan.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class SignUpRequestDTO {
 
     @NotBlank
+    @Size(min = 4, max = 6, message = "닉네임은 4자 이상 6자 이하로 입력해주세요.")
+    @Pattern(
+            regexp = "^(?!\\d+$)[a-zA-Z0-9가-힣]+$",
+            message = "닉네임은 한글, 영문자, 숫자만 사용 가능하며 숫자만으로 구성할 수 없습니다."
+    )
     private String nickname;
 
     @NotBlank
-    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]{7,15}$") // 영문자, 숫자를 포함한 7글자 이상 15글자 이하
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]{7,15}$",
+            message = "아이디는 영문자와 숫자를 포함하여 7자 이상 15자 이하로 입력해주세요.")
     private String userId;
 
     @NotBlank
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@#$%^&+=!]).{8,}$") // 영문자, 특수문자, 숫자를 포함한 최소 8자 이상의 문자
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+\\[\\]{};':\"\\\\|,.<>/?]).{8,}$",
+            message = "비밀번호는 영문자, 숫자, 특수문자를 포함한 최소 8자 이상이어야 합니다.")
     private String password;
 
     private String checkPassword;

--- a/src/main/java/com/se/dandan/dto/TokenInfo.java
+++ b/src/main/java/com/se/dandan/dto/TokenInfo.java
@@ -13,8 +13,6 @@ public class TokenInfo {
 
     private String accessToken;
 
-    private String refreshToken;
-
     private String role;
 
     @Builder

--- a/src/main/java/com/se/dandan/dto/TokenInfo.java
+++ b/src/main/java/com/se/dandan/dto/TokenInfo.java
@@ -1,4 +1,18 @@
 package com.se.dandan.dto;
 
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TokenInfo {
+
+    private String grantType;
+
+    private String accessToken;
+
+    private String refreshToken;
+
+    private String role;
 }

--- a/src/main/java/com/se/dandan/dto/TokenInfo.java
+++ b/src/main/java/com/se/dandan/dto/TokenInfo.java
@@ -1,6 +1,7 @@
 package com.se.dandan.dto;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -15,4 +16,11 @@ public class TokenInfo {
     private String refreshToken;
 
     private String role;
+
+    @Builder
+    public TokenInfo(String grantType, String accessToken, String role) {
+        this.grantType = grantType;
+        this.accessToken = accessToken;
+        this.role = role;
+    }
 }

--- a/src/main/java/com/se/dandan/entity/Member.java
+++ b/src/main/java/com/se/dandan/entity/Member.java
@@ -1,4 +1,27 @@
 package com.se.dandan.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nickname;
+
+    private String userId;
+
+    private String password;
+
 }

--- a/src/main/java/com/se/dandan/entity/Member.java
+++ b/src/main/java/com/se/dandan/entity/Member.java
@@ -1,9 +1,6 @@
 package com.se.dandan.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -23,5 +20,10 @@ public class Member {
     private String userId;
 
     private String password;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
+
+    private int wordCount;
 
 }

--- a/src/main/java/com/se/dandan/entity/MemberRole.java
+++ b/src/main/java/com/se/dandan/entity/MemberRole.java
@@ -1,0 +1,6 @@
+package com.se.dandan.entity;
+
+public enum MemberRole {
+    ADMIN, // 관리자
+    MEMBER, // 일반 사용자
+}

--- a/src/main/java/com/se/dandan/exception/ErrorResponse.java
+++ b/src/main/java/com/se/dandan/exception/ErrorResponse.java
@@ -1,0 +1,18 @@
+package com.se.dandan.exception;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ErrorResponse {
+
+    private final LocalDateTime timestamp = LocalDateTime.now();
+    private final int status;
+    private final String message;
+
+    public ErrorResponse(ErrorCode code) {
+        this.status = code.getHttpStatus().value();
+        this.message = code.getMessage();
+    }
+}

--- a/src/main/java/com/se/dandan/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/se/dandan/exception/GlobalExceptionHandler.java
@@ -1,7 +1,46 @@
 package com.se.dandan.exception;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> httpMethodExceptionHandler(HttpRequestMethodNotSupportedException e) {
+        log.error("HttpRequestMethodNotSupportedException: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.METHOD_NOT_ALLOWED.getHttpStatus())
+                .body(new ErrorResponse(ErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorResponse> CustomExceptionHandler(CustomException e) {
+        log.error("CustomException: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus().value())
+                .body(new ErrorResponse(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> internalSeverExceptionHandler(Exception e) {
+        log.error("INTERNAL_SERVER_ERROR: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus().value())
+                .body(new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler({MethodArgumentNotValidException.class, HttpMessageNotReadableException.class})
+    protected ResponseEntity<ErrorResponse> validationExceptionHandler(Exception e) {
+        log.error("Validation Fail: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.VALIDATION_FAIL.getHttpStatus().value())
+                .body(new ErrorResponse(ErrorCode.VALIDATION_FAIL));
+    }
 }

--- a/src/main/java/com/se/dandan/filter/JWTAuthenticationFilter.java
+++ b/src/main/java/com/se/dandan/filter/JWTAuthenticationFilter.java
@@ -7,6 +7,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -21,6 +23,21 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
 
+        if (token != null && jwtProvider.validateToken(token)) {
+            Authentication auth = jwtProvider.getAuthentication(token); // 사용자 추출
+            SecurityContextHolder.getContext().setAuthentication(auth); // SecurityContextHolder에 사용자 등록
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) { // 헤더에서 토큰 추출
+        String bearerToken = request.getHeader("Authorization"); // 헤더의 Authorization에서 값을 가져옴.
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) { // Bearer를 제외한 토큰 값 가져오기
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/se/dandan/repository/MemberRepository.java
+++ b/src/main/java/com/se/dandan/repository/MemberRepository.java
@@ -1,4 +1,8 @@
 package com.se.dandan.repository;
 
-public interface MemberRepository {
+import com.se.dandan.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Member findByNickname(String nickname);
 }

--- a/src/main/java/com/se/dandan/repository/MemberRepository.java
+++ b/src/main/java/com/se/dandan/repository/MemberRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Member findByNickname(String nickname);
+
+    boolean existsByUserId(String userId);
 }

--- a/src/main/java/com/se/dandan/repository/MemberRepository.java
+++ b/src/main/java/com/se/dandan/repository/MemberRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Member findByNickname(String nickname);
 
+    Member findByUserId(String userId);
+
     boolean existsByUserId(String userId);
 }

--- a/src/main/java/com/se/dandan/service/AuthService.java
+++ b/src/main/java/com/se/dandan/service/AuthService.java
@@ -1,7 +1,32 @@
 package com.se.dandan.service;
 
+import com.se.dandan.dto.IdCheckRequestDTO;
+import com.se.dandan.dto.SignUpRequestDTO;
+import com.se.dandan.entity.Member;
+import com.se.dandan.exception.CustomException;
+import com.se.dandan.exception.ErrorCode;
+import com.se.dandan.repository.MemberRepository;
+import com.se.dandan.util.JWTProvider;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final JWTProvider jwtProvider;
+
+    public AuthService(MemberRepository memberRepository, BCryptPasswordEncoder bCryptPasswordEncoder, JWTProvider jwtProvider) {
+        this.memberRepository = memberRepository;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+        this.jwtProvider = jwtProvider;
+    }
+
+    public void idCheck(IdCheckRequestDTO idCheckRequestDTO) {
+        boolean existedUserId = memberRepository.existsByUserId(idCheckRequestDTO.getUserId());
+        if (existedUserId) {
+            throw new CustomException(ErrorCode.DUPLICATED_ID);
+        }
+    }
 }

--- a/src/main/java/com/se/dandan/service/AuthService.java
+++ b/src/main/java/com/se/dandan/service/AuthService.java
@@ -3,6 +3,7 @@ package com.se.dandan.service;
 import com.se.dandan.dto.IdCheckRequestDTO;
 import com.se.dandan.dto.SignUpRequestDTO;
 import com.se.dandan.entity.Member;
+import com.se.dandan.entity.MemberRole;
 import com.se.dandan.exception.CustomException;
 import com.se.dandan.exception.ErrorCode;
 import com.se.dandan.repository.MemberRepository;
@@ -28,5 +29,38 @@ public class AuthService {
         if (existedUserId) {
             throw new CustomException(ErrorCode.DUPLICATED_ID);
         }
+    }
+
+    public void signUp(SignUpRequestDTO signUpRequestDTO) {
+        String nickname = signUpRequestDTO.getNickname();
+
+        String userId = signUpRequestDTO.getUserId();
+        boolean existedUserId = memberRepository.existsByUserId(userId);
+
+        if (existedUserId) {
+            throw new CustomException(ErrorCode.DUPLICATED_ID);
+        }
+
+        String password = signUpRequestDTO.getPassword();
+        String checkPassword = signUpRequestDTO.getCheckPassword();
+
+        if(!password.equals(checkPassword)) {
+            throw new CustomException(ErrorCode.NOT_MATCHED_PASSWORD);
+        }
+
+        String encodedPassword = bCryptPasswordEncoder.encode(password);
+        signUpRequestDTO.setPassword(encodedPassword);
+
+        int wordCount = signUpRequestDTO.getWordCount();
+
+        Member member = Member.builder()
+                .nickname(nickname)
+                .userId(userId)
+                .password(encodedPassword)
+                .wordCount(wordCount)
+                .role(MemberRole.MEMBER)
+                .build();
+
+        memberRepository.save(member);
     }
 }

--- a/src/main/java/com/se/dandan/service/AuthService.java
+++ b/src/main/java/com/se/dandan/service/AuthService.java
@@ -1,13 +1,18 @@
 package com.se.dandan.service;
 
 import com.se.dandan.dto.IdCheckRequestDTO;
+import com.se.dandan.dto.SignInRequestDTO;
 import com.se.dandan.dto.SignUpRequestDTO;
+import com.se.dandan.dto.TokenInfo;
 import com.se.dandan.entity.Member;
 import com.se.dandan.entity.MemberRole;
 import com.se.dandan.exception.CustomException;
 import com.se.dandan.exception.ErrorCode;
 import com.se.dandan.repository.MemberRepository;
 import com.se.dandan.util.JWTProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -17,11 +22,16 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final JWTProvider jwtProvider;
+    private final int refreshedMS;
 
-    public AuthService(MemberRepository memberRepository, BCryptPasswordEncoder bCryptPasswordEncoder, JWTProvider jwtProvider) {
+    public AuthService(MemberRepository memberRepository,
+                       BCryptPasswordEncoder bCryptPasswordEncoder,
+                       JWTProvider jwtProvider,
+                       @Value("${jwt.refreshedMs}") int refreshedMS) {
         this.memberRepository = memberRepository;
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
         this.jwtProvider = jwtProvider;
+        this.refreshedMS = refreshedMS;
     }
 
     public void idCheck(IdCheckRequestDTO idCheckRequestDTO) {
@@ -62,5 +72,42 @@ public class AuthService {
                 .build();
 
         memberRepository.save(member);
+    }
+
+    public TokenInfo signIn(SignInRequestDTO signInRequestDTO, HttpServletResponse response) {
+        String userId = signInRequestDTO.getUserId();
+
+        Member member = memberRepository.findByUserId(userId);
+        if(member == null) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        String password = signInRequestDTO.getPassword();
+        String encodedPassword = member.getPassword();
+
+        boolean isMatched = bCryptPasswordEncoder.matches(password, encodedPassword);
+        if(!isMatched) {
+            throw new CustomException(ErrorCode.SIGN_IN_FAILED);
+        }
+
+        String nickname = member.getNickname();
+
+        String role = member.getRole().name();
+
+        TokenInfo token = jwtProvider.generateToken(nickname, role);
+        String refreshToken = jwtProvider.generateRefreshToken(nickname, role);
+
+        response.addCookie(createCookie(refreshToken));
+
+        return token;
+    }
+
+    private Cookie createCookie(String value) {
+        Cookie cookie = new Cookie("Refresh", value);
+        cookie.setMaxAge(refreshedMS / 1000);
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
+
+        return cookie;
     }
 }

--- a/src/main/java/com/se/dandan/util/JWTProvider.java
+++ b/src/main/java/com/se/dandan/util/JWTProvider.java
@@ -1,7 +1,125 @@
 package com.se.dandan.util;
 
+import com.se.dandan.dto.TokenInfo;
+import com.se.dandan.entity.Member;
+import com.se.dandan.exception.CustomException;
+import com.se.dandan.exception.ErrorCode;
+import com.se.dandan.repository.MemberRepository;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.SecurityException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+@Slf4j
 @Component
 public class JWTProvider {
+
+    private SecretKey secretKey;
+
+    private final long expiredMs;
+
+    private final long refreshedMs;
+
+    private final MemberRepository memberRepository;
+
+    public JWTProvider(@Value("${jwt.secret}") String secret,
+                       @Value("${jwt.expiredMS}") long expiredMs,
+                       @Value("${jwt.refreshedMs}")long refreshedMs,
+                       MemberRepository memberRepository) {
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+        this.expiredMs = expiredMs;
+        this.refreshedMs = refreshedMs;
+        this.memberRepository = memberRepository;
+    }
+
+    public String generateAccessToken(String nickname, String role) {
+        Date now = new Date();
+        Date accessTokenExpiredAt = new Date(now.getTime() + expiredMs);
+
+        return Jwts.builder()
+                .subject(nickname)
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(accessTokenExpiredAt)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String generateRefreshToken(String nickname, String role) {
+        Date now = new Date();
+        Date refreshTokenExpiredAt = new Date(now.getTime() + refreshedMs);
+
+        return Jwts.builder()
+                .subject(nickname)
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(refreshTokenExpiredAt)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
+            return true;
+        }
+        catch (SecurityException | MalformedJwtException e) {
+            log.error("Signature verification failed");
+            throw new JwtException("잘못된 JWT 서명 입니다.");
+        }
+        catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token");
+            throw new JwtException("지원하지 않는 토큰 입니다.");
+        }
+        catch (ExpiredJwtException e) {
+            log.error("Expired JWT token");
+            throw new JwtException("만료된 토큰 입니다.");
+        }
+        catch (IllegalArgumentException e) {
+            log.error("JWT claims string is empty");
+        }
+
+        return false;
+    }
+
+    public TokenInfo generateToken(String nickname, String role) {
+
+        String accessToken = generateAccessToken(nickname, role);
+
+        return TokenInfo.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .role(role)
+                .build();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
+
+        String nickname = claims.getSubject();
+
+        String role = claims.get("role", String.class);
+
+        Member member = memberRepository.findByNickname(nickname);
+
+        if (member == null) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role));
+
+        return new UsernamePasswordAuthenticationToken(nickname, token, authorities);
+    }
 }


### PR DESCRIPTION
## 📌 개요
- DANDAN의 회원 가입 및 로그인 기능을 구현 완료 하였습니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #3

## ✅ 변경 사항
- 회원 가입 기능 추가
  - 닉네임 입력(4~6자)
  - 아이디 입력(영문자, 숫자 포함 7 ~ 15자)
  - 아이디 중복 확인
  - 비밀번호 입력(영문자, 숫자, 특수문자 포함 최소 8자 이상)
  - 비밀번호 재확인 
  - 목표 단어 개수 설정(공백X)
- 로그인 기능 추가
  - 아이디
  - 비밀번호 

## 📝 상세 내용
- 회원가입
  - 닉네임, 아이디, 비밀번호, 비밀번호 재확인, 목표 단어 개수를 입력합니다.
  - 아이디 중복 확인을 진행합니다.
  - 요구한 입력 형식에 맞지 않은 경우, 예외처리가 발생합니다. 
- 로그인
  - 아이디, 비밀번호를 입력합니다.
  - 로그인 성공 시, 응답 body에 사용자 권한과 Access 토큰이, 쿠키에 Refresh 토큰이 담겨 반환 됩니다.
  - 로그인 실패 시, 예외처리가 발생합니다.

## 📸 스크린샷
- 회원가입 성공 예시
![image](https://github.com/user-attachments/assets/fed0099b-a568-41c1-9de0-e17897677bdb)

- 로그인 성공 예시
  - 응답 body Access 토큰 반환 
  ![image](https://github.com/user-attachments/assets/ae97b553-4820-4f51-9c96-f32f0da800a3)
  - 쿠키 Refresh 토큰 반환
  ![image](https://github.com/user-attachments/assets/44fe4f44-e1bc-461e-acef-d65ab03c0611)

