### PR TITLE
[Hotfix] JWT 토큰 생성 시, 토큰에 넣을 사용자 정보 수정 완료

### DIFF
--- a/src/main/java/com/se/dandan/controller/CheckMemberController.java
+++ b/src/main/java/com/se/dandan/controller/CheckMemberController.java
@@ -2,15 +2,24 @@ package com.se.dandan.controller;
 
 import com.se.dandan.dto.MemberPrincipalDTO;
 import com.se.dandan.dto.common.ResponseTemplate;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "CheckMember API", description = "현재 사용자 정보 추출 API")
 @RestController
 public class CheckMemberController {
 
+    @Operation(summary = "사용자 확인 컨트롤러", description = "사용자 확인을 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @GetMapping("/test")
     public ResponseTemplate<String> test(@AuthenticationPrincipal MemberPrincipalDTO member) {
 

--- a/src/main/java/com/se/dandan/controller/CheckMemberController.java
+++ b/src/main/java/com/se/dandan/controller/CheckMemberController.java
@@ -1,0 +1,22 @@
+package com.se.dandan.controller;
+
+import com.se.dandan.dto.MemberPrincipalDTO;
+import com.se.dandan.dto.common.ResponseTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CheckMemberController {
+
+    @GetMapping("/test")
+    public ResponseTemplate<String> test(@AuthenticationPrincipal MemberPrincipalDTO member) {
+
+        String nickname = member.getNickname();
+        String role = SecurityContextHolder.getContext().getAuthentication().getAuthorities().iterator().next().getAuthority();
+
+        return new ResponseTemplate<>(HttpStatus.OK, "환영합니다, " + role + ", " + nickname + "님!", nickname);
+    }
+}

--- a/src/main/java/com/se/dandan/dto/MemberPrincipalDTO.java
+++ b/src/main/java/com/se/dandan/dto/MemberPrincipalDTO.java
@@ -1,0 +1,13 @@
+package com.se.dandan.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MemberPrincipalDTO {
+
+    private Long id;
+
+    private String nickname;
+}

--- a/src/main/java/com/se/dandan/dto/MemberPrincipalDTO.java
+++ b/src/main/java/com/se/dandan/dto/MemberPrincipalDTO.java
@@ -1,13 +1,17 @@
 package com.se.dandan.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
+@Schema(description = "로그인 시, 사용자 정보 저장 DTO")
 @Data
 @Builder
 public class MemberPrincipalDTO {
 
+    @Schema(description = "DB 상의 PK 값")
     private Long id;
 
+    @Schema(description = "사용자 닉네임")
     private String nickname;
 }

--- a/src/main/java/com/se/dandan/repository/MemberRepository.java
+++ b/src/main/java/com/se/dandan/repository/MemberRepository.java
@@ -3,10 +3,12 @@ package com.se.dandan.repository;
 import com.se.dandan.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Member findByNickname(String nickname);
 
-    Member findByUserId(String userId);
+    Optional<Member> findByUserId(String userId);
 
     boolean existsByUserId(String userId);
 }

--- a/src/main/java/com/se/dandan/service/AuthService.java
+++ b/src/main/java/com/se/dandan/service/AuthService.java
@@ -88,12 +88,10 @@ public class AuthService {
             throw new CustomException(ErrorCode.SIGN_IN_FAILED);
         }
 
-        String nickname = member.getNickname();
-
         String role = member.getRole().name();
 
-        TokenInfo token = jwtProvider.generateToken(nickname, role);
-        String refreshToken = jwtProvider.generateRefreshToken(nickname, role);
+        TokenInfo token = jwtProvider.generateToken(userId, role);
+        String refreshToken = jwtProvider.generateRefreshToken(userId, role);
 
         response.addCookie(createCookie(refreshToken));
 

--- a/src/main/java/com/se/dandan/service/AuthService.java
+++ b/src/main/java/com/se/dandan/service/AuthService.java
@@ -77,10 +77,8 @@ public class AuthService {
     public TokenInfo signIn(SignInRequestDTO signInRequestDTO, HttpServletResponse response) {
         String userId = signInRequestDTO.getUserId();
 
-        Member member = memberRepository.findByUserId(userId);
-        if(member == null) {
-            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
-        }
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         String password = signInRequestDTO.getPassword();
         String encodedPassword = member.getPassword();

--- a/src/main/java/com/se/dandan/util/JWTProvider.java
+++ b/src/main/java/com/se/dandan/util/JWTProvider.java
@@ -1,5 +1,6 @@
 package com.se.dandan.util;
 
+import com.se.dandan.dto.MemberPrincipalDTO;
 import com.se.dandan.dto.TokenInfo;
 import com.se.dandan.entity.Member;
 import com.se.dandan.exception.CustomException;
@@ -117,6 +118,11 @@ public class JWTProvider {
 
         List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role));
 
-        return new UsernamePasswordAuthenticationToken(userId, token, authorities);
+        MemberPrincipalDTO memberPrincipalDTO = MemberPrincipalDTO.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .build();
+
+        return new UsernamePasswordAuthenticationToken(memberPrincipalDTO, token, authorities);
     }
 }

--- a/src/main/java/com/se/dandan/util/JWTProvider.java
+++ b/src/main/java/com/se/dandan/util/JWTProvider.java
@@ -44,12 +44,12 @@ public class JWTProvider {
         this.memberRepository = memberRepository;
     }
 
-    public String generateAccessToken(String nickname, String role) {
+    public String generateAccessToken(String userId, String role) {
         Date now = new Date();
         Date accessTokenExpiredAt = new Date(now.getTime() + expiredMs);
 
         return Jwts.builder()
-                .subject(nickname)
+                .subject(userId)
                 .claim("role", role)
                 .issuedAt(now)
                 .expiration(accessTokenExpiredAt)
@@ -57,12 +57,12 @@ public class JWTProvider {
                 .compact();
     }
 
-    public String generateRefreshToken(String nickname, String role) {
+    public String generateRefreshToken(String userId, String role) {
         Date now = new Date();
         Date refreshTokenExpiredAt = new Date(now.getTime() + refreshedMs);
 
         return Jwts.builder()
-                .subject(nickname)
+                .subject(userId)
                 .claim("role", role)
                 .issuedAt(now)
                 .expiration(refreshTokenExpiredAt)
@@ -94,9 +94,9 @@ public class JWTProvider {
         return false;
     }
 
-    public TokenInfo generateToken(String nickname, String role) {
+    public TokenInfo generateToken(String userId, String role) {
 
-        String accessToken = generateAccessToken(nickname, role);
+        String accessToken = generateAccessToken(userId, role);
 
         return TokenInfo.builder()
                 .grantType("Bearer")
@@ -108,18 +108,15 @@ public class JWTProvider {
     public Authentication getAuthentication(String token) {
         Claims claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
 
-        String nickname = claims.getSubject();
+        String userId = claims.getSubject();
 
         String role = claims.get("role", String.class);
 
-        Member member = memberRepository.findByNickname(nickname);
-
-        if (member == null) {
-            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
-        }
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role));
 
-        return new UsernamePasswordAuthenticationToken(nickname, token, authorities);
+        return new UsernamePasswordAuthenticationToken(userId, token, authorities);
     }
 }


### PR DESCRIPTION
## 📌 개요
- JWT 토큰 생성 시, 토큰에 넣을 사용자 정보를 수정하였습니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #5 

## ✅ 변경 사항
- JWT 토큰 생성 시, 토큰에 들어갈 정보를 수정하였습니다.
- JWT 로그인 시, SecurityContextHolder에 저장할 사용자의 정보를 선택적으로 넣을 수 있게 하였습니다.
- JWT 토큰을 통해, 현재 로그인한 사용자의 정보를 확인할 수 있는 컨트롤러를 구현하였습니다.

## 📝 상세 내용
- JWT 토큰 생성 시, 토큰에 '사용자의 아이디'와 Role이 들어갑니다.
- 기존 코드에서는 JWT 로그인 시 SecurityContextHolder에 사용자의 닉네임값만 String으로 저장되었지만,  보안상의 문제가 있을 수 있다고 판단되어 사용자의 특정 정보만 들어갈 수 있게 수정하였습니다. 
- CheckMember Controller를 통해 헤더의 Authorization란에 AccessToken을 넣어 현재 사용자의 닉네임과  role을 확인할 수 있습니다.

## 📸 스크린샷
CheckMember Controller 예시
![image](https://github.com/user-attachments/assets/edaee27d-89e7-4cb6-b4bc-f841f710d2ef)