### PR TITLE
[Feature] 마이페이지 기능 구현 완료

### DIFF
--- a/src/main/java/com/se/dandan/config/SwaggerConfig.java
+++ b/src/main/java/com/se/dandan/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.se.dandan.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,7 +14,9 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .info(customInfo());
+                .info(customInfo())
+                .addSecurityItem(customSecurityRequirement())
+                .components(customComponents());
     }
 
     private Info customInfo() {
@@ -19,5 +24,23 @@ public class SwaggerConfig {
                 .title("DANDAN API Document")
                 .version("1.0")
                 .description("DANDAN API 문서");
+    }
+
+    String authName = "Json Web Token";
+
+    private SecurityRequirement customSecurityRequirement() {
+        return new SecurityRequirement()
+                .addList(authName);
+    }
+
+    private Components customComponents() {
+        return new Components().addSecuritySchemes(authName,
+                new SecurityScheme()
+                        .name(authName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT")
+                        .description("Access Token을 입력해주세요.(Bearer 제외)")
+        );
     }
 }

--- a/src/main/java/com/se/dandan/controller/MemberController.java
+++ b/src/main/java/com/se/dandan/controller/MemberController.java
@@ -18,12 +18,18 @@ public class MemberController {
         this.memberService = memberService;
     }
 
-    @GetMapping("/my-page")
-    public ResponseTemplate<MemberInfoDTO> memberInfo(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO) {
-        String userId = memberPrincipalDTO.getUserId();
-        MemberInfoDTO memberInfo = memberService.loadMemberInfo(userId);
+    @GetMapping("/my-page/get-nickname")
+    public ResponseTemplate<String> getNickname(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO) {
+        String nickname = memberPrincipalDTO.getNickname();
 
-        return new ResponseTemplate<>(HttpStatus.OK, "회원 정보 조회 성공", memberInfo);
+        return new ResponseTemplate<>(HttpStatus.OK, "회원 닉네임 조회 성공", nickname);
+    }
+
+    @GetMapping("/my-page/get-userId")
+    public ResponseTemplate<String> getUserId(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO) {
+        String userId = memberPrincipalDTO.getUserId();
+
+        return new ResponseTemplate<>(HttpStatus.OK, "회원 아이디 조회 성공", userId);
     }
 
     @PostMapping("/my-page/edit")

--- a/src/main/java/com/se/dandan/controller/MemberController.java
+++ b/src/main/java/com/se/dandan/controller/MemberController.java
@@ -6,9 +6,7 @@ import com.se.dandan.dto.common.ResponseTemplate;
 import com.se.dandan.service.MemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/member")
@@ -26,5 +24,14 @@ public class MemberController {
         MemberInfoDTO memberInfo = memberService.loadMemberInfo(userId);
 
         return new ResponseTemplate<>(HttpStatus.OK, "회원 정보 조회 성공", memberInfo);
+    }
+
+    @PostMapping("/my-page/edit")
+    public ResponseTemplate<?> editMemberInfo(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO,
+                                              @RequestBody MemberInfoDTO memberInfoDTO) {
+        String userId = memberPrincipalDTO.getUserId();
+        memberService.updateMemberInfo(userId, memberInfoDTO);
+
+        return new ResponseTemplate<>(HttpStatus.OK, "회원정보 수정 성공");
     }
 }

--- a/src/main/java/com/se/dandan/controller/MemberController.java
+++ b/src/main/java/com/se/dandan/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.se.dandan.controller;
 
 import com.se.dandan.dto.MemberInfoDTO;
 import com.se.dandan.dto.MemberPrincipalDTO;
+import com.se.dandan.dto.WordCountDTO;
 import com.se.dandan.dto.common.ResponseTemplate;
 import com.se.dandan.service.MemberService;
 import org.springframework.http.HttpStatus;
@@ -32,12 +33,28 @@ public class MemberController {
         return new ResponseTemplate<>(HttpStatus.OK, "회원 아이디 조회 성공", userId);
     }
 
-    @PostMapping("/my-page/edit")
+    @GetMapping("/my-page/get-word-count")
+    public ResponseTemplate<Integer> getWordCount(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO) {
+        String userId = memberPrincipalDTO.getUserId();
+        int wordCount = memberService.getWordCount(userId);
+        return new ResponseTemplate<>(HttpStatus.OK, "회원 목표 단어 개수 조회 성공", wordCount);
+    }
+
+    @PostMapping("/my-page/edit-info")
     public ResponseTemplate<?> editMemberInfo(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO,
                                               @RequestBody MemberInfoDTO memberInfoDTO) {
         String userId = memberPrincipalDTO.getUserId();
         memberService.updateMemberInfo(userId, memberInfoDTO);
 
         return new ResponseTemplate<>(HttpStatus.OK, "회원정보 수정 성공");
+    }
+
+    @PostMapping("/my-page/edit-word-count")
+    public ResponseTemplate<Integer> editWordCount(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO,
+                                                   @RequestBody WordCountDTO wordCountDTO) {
+        String userId = memberPrincipalDTO.getUserId();
+        memberService.updateWordCount(userId, wordCountDTO);
+
+        return new ResponseTemplate<>(HttpStatus.OK, "목표 단어 개수 수정 성공");
     }
 }

--- a/src/main/java/com/se/dandan/controller/MemberController.java
+++ b/src/main/java/com/se/dandan/controller/MemberController.java
@@ -1,0 +1,30 @@
+package com.se.dandan.controller;
+
+import com.se.dandan.dto.MemberInfoDTO;
+import com.se.dandan.dto.MemberPrincipalDTO;
+import com.se.dandan.dto.common.ResponseTemplate;
+import com.se.dandan.service.MemberService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @GetMapping("/my-page")
+    public ResponseTemplate<MemberInfoDTO> memberInfo(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO) {
+        String userId = memberPrincipalDTO.getUserId();
+        MemberInfoDTO memberInfo = memberService.loadMemberInfo(userId);
+
+        return new ResponseTemplate<>(HttpStatus.OK, "회원 정보 조회 성공", memberInfo);
+    }
+}

--- a/src/main/java/com/se/dandan/dto/MemberInfoDTO.java
+++ b/src/main/java/com/se/dandan/dto/MemberInfoDTO.java
@@ -9,7 +9,5 @@ public class MemberInfoDTO {
 
     private String nickname;
 
-    private String userId;
-
     private String password;
 }

--- a/src/main/java/com/se/dandan/dto/MemberInfoDTO.java
+++ b/src/main/java/com/se/dandan/dto/MemberInfoDTO.java
@@ -1,0 +1,15 @@
+package com.se.dandan.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MemberInfoDTO {
+
+    private String nickname;
+
+    private String userId;
+
+    private String password;
+}

--- a/src/main/java/com/se/dandan/dto/MemberPrincipalDTO.java
+++ b/src/main/java/com/se/dandan/dto/MemberPrincipalDTO.java
@@ -14,4 +14,7 @@ public class MemberPrincipalDTO {
 
     @Schema(description = "사용자 닉네임")
     private String nickname;
+
+    @Schema(description = "사용자 아이디")
+    private String userId;
 }

--- a/src/main/java/com/se/dandan/dto/SignUpRequestDTO.java
+++ b/src/main/java/com/se/dandan/dto/SignUpRequestDTO.java
@@ -11,7 +11,7 @@ import lombok.Data;
 @Data
 public class SignUpRequestDTO {
 
-    @Schema(description = "사용자 이름", example = "홍길동")
+    @Schema(description = "사용자 이름", example = "소공에이")
     @NotBlank
     @Size(min = 4, max = 6, message = "닉네임은 4자 이상 6자 이하로 입력해주세요.")
     @Pattern(

--- a/src/main/java/com/se/dandan/dto/WordCountDTO.java
+++ b/src/main/java/com/se/dandan/dto/WordCountDTO.java
@@ -1,0 +1,9 @@
+package com.se.dandan.dto;
+
+import lombok.Data;
+
+@Data
+public class WordCountDTO {
+
+    private int wordCount;
+}

--- a/src/main/java/com/se/dandan/service/MemberService.java
+++ b/src/main/java/com/se/dandan/service/MemberService.java
@@ -23,17 +23,6 @@ public class MemberService {
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
     }
 
-    public MemberInfoDTO loadMemberInfo(String userId) {
-        Member member = memberRepository.findByUserId(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
-        return MemberInfoDTO.builder()
-                .nickname(member.getNickname())
-                .userId(member.getUserId())
-                .password(bCryptPasswordEncoder.encode(member.getPassword()))
-                .build();
-    }
-
     public void updateMemberInfo(String userId, MemberInfoDTO memberInfoDTO) {
         Member member = memberRepository.findByUserId(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
@@ -46,7 +35,7 @@ public class MemberService {
             String password = info.getPassword();
 
             if(nickname != null) {
-                if(nickname.length() < 4 || nickname.length() > 6) {
+                if(!nickname.matches("^(?!\\d+$)[a-zA-Z0-9가-힣]+$")) {
                     throw new CustomException(ErrorCode.VALIDATION_FAIL);
                 }
                 member.setNickname(nickname);

--- a/src/main/java/com/se/dandan/service/MemberService.java
+++ b/src/main/java/com/se/dandan/service/MemberService.java
@@ -8,6 +8,9 @@ import com.se.dandan.repository.MemberRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 public class MemberService {
 
@@ -29,5 +32,34 @@ public class MemberService {
                 .userId(member.getUserId())
                 .password(bCryptPasswordEncoder.encode(member.getPassword()))
                 .build();
+    }
+
+    public void updateMemberInfo(String userId, MemberInfoDTO memberInfoDTO) {
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<MemberInfoDTO> list = new ArrayList<>();
+        list.add(memberInfoDTO);
+
+        for(MemberInfoDTO info : list) {
+            String nickname = info.getNickname();
+            String password = info.getPassword();
+
+            if(nickname != null) {
+                if(nickname.length() < 4 || nickname.length() > 6) {
+                    throw new CustomException(ErrorCode.VALIDATION_FAIL);
+                }
+                member.setNickname(nickname);
+            }
+
+            if(password != null) {
+                if(password.isEmpty() || !password.matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+\\[\\]{};':\"\\\\|,.<>/?]).{8,}$")) {
+                    throw new CustomException(ErrorCode.VALIDATION_FAIL);
+                }
+                member.setPassword(bCryptPasswordEncoder.encode(password));
+            }
+        }
+
+        memberRepository.save(member);
     }
 }

--- a/src/main/java/com/se/dandan/service/MemberService.java
+++ b/src/main/java/com/se/dandan/service/MemberService.java
@@ -1,0 +1,33 @@
+package com.se.dandan.service;
+
+import com.se.dandan.dto.MemberInfoDTO;
+import com.se.dandan.entity.Member;
+import com.se.dandan.exception.CustomException;
+import com.se.dandan.exception.ErrorCode;
+import com.se.dandan.repository.MemberRepository;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public MemberService(MemberRepository memberRepository,  BCryptPasswordEncoder bCryptPasswordEncoder) {
+        this.memberRepository = memberRepository;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+    }
+
+    public MemberInfoDTO loadMemberInfo(String userId) {
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return MemberInfoDTO.builder()
+                .nickname(member.getNickname())
+                .userId(member.getUserId())
+                .password(bCryptPasswordEncoder.encode(member.getPassword()))
+                .build();
+    }
+}

--- a/src/main/java/com/se/dandan/service/MemberService.java
+++ b/src/main/java/com/se/dandan/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.se.dandan.service;
 
 import com.se.dandan.dto.MemberInfoDTO;
+import com.se.dandan.dto.WordCountDTO;
 import com.se.dandan.entity.Member;
 import com.se.dandan.exception.CustomException;
 import com.se.dandan.exception.ErrorCode;
@@ -21,6 +22,27 @@ public class MemberService {
     public MemberService(MemberRepository memberRepository,  BCryptPasswordEncoder bCryptPasswordEncoder) {
         this.memberRepository = memberRepository;
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+    }
+
+    public int getWordCount(String userId) {
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return member.getWordCount();
+    }
+
+    public void updateWordCount(String userId, WordCountDTO wordCountDTO) {
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        int wordCount = wordCountDTO.getWordCount();
+
+        if(wordCount <= 0) {
+            throw new CustomException(ErrorCode.VALIDATION_FAIL);
+        }
+
+        member.setWordCount(wordCount);
+        memberRepository.save(member);
     }
 
     public void updateMemberInfo(String userId, MemberInfoDTO memberInfoDTO) {

--- a/src/main/java/com/se/dandan/util/JWTProvider.java
+++ b/src/main/java/com/se/dandan/util/JWTProvider.java
@@ -121,6 +121,7 @@ public class JWTProvider {
         MemberPrincipalDTO memberPrincipalDTO = MemberPrincipalDTO.builder()
                 .id(member.getId())
                 .nickname(member.getNickname())
+                .userId(member.getUserId())
                 .build();
 
         return new UsernamePasswordAuthenticationToken(memberPrincipalDTO, token, authorities);


### PR DESCRIPTION
## 📌 개요
- DANDAN의 마이페이지 기능 구현을 완료하였습니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #7 

## ✅ 변경 사항
- DANDAN 마이페이지 기능 추가
  - 사용자 정보 조회
    - 사용자 아이디
    - 사용자 닉네임
    - 사용자 목표 단어 개수
  - 사용자 정보 수정
    - 사용자 닉네임, 비밀번호
    - 사용자 목표 단어 개수    

## 📝 상세 내용
- DANDAN 회원의 정보를 조회하고 수정하는 기능이 추가 되었습니다.
[사용자 정보 조회 기능]
- 사용자의 닉네임과 아이디를 조회 할 수 있습니다.
- 사용자의 목표 단어 개수를 조회할 수 있습니다.

[사용자 정보 수정 기능]
- 사용자의 닉네임과 비밀번호를 수정할 수 있습니다.
  - 정보 수정은 닉네임과 비밀번호 둘 중에 하나 또는 둘 다 수정해도 수정이 가능합니다.  
- 사용자의 목표 단어 개수를 수정할 수 있습니다.
