### PR TITLE
[Feature] 단어 학습 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/se/dandan/config/SecurityConfig.java
+++ b/src/main/java/com/se/dandan/config/SecurityConfig.java
@@ -33,7 +33,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.ignoringRequestMatchers("/h2-console/**")); // csrf 비활성화
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/h2-console/**"));
+        http
+                .csrf(AbstractHttpConfigurer::disable);// csrf 비활성화
 
         http
                 .httpBasic(AbstractHttpConfigurer::disable); // httpBasic 비활성화

--- a/src/main/java/com/se/dandan/controller/MemberController.java
+++ b/src/main/java/com/se/dandan/controller/MemberController.java
@@ -5,6 +5,9 @@ import com.se.dandan.dto.MemberPrincipalDTO;
 import com.se.dandan.dto.WordCountDTO;
 import com.se.dandan.dto.common.ResponseTemplate;
 import com.se.dandan.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +22,10 @@ public class MemberController {
         this.memberService = memberService;
     }
 
+    @Operation(summary = "마이페이지 닉네임 조회 컨트롤러", description = "마이페이지 닉네임 조회를 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @GetMapping("/my-page/get-nickname")
     public ResponseTemplate<String> getNickname(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO) {
         String nickname = memberPrincipalDTO.getNickname();
@@ -26,6 +33,10 @@ public class MemberController {
         return new ResponseTemplate<>(HttpStatus.OK, "회원 닉네임 조회 성공", nickname);
     }
 
+    @Operation(summary = "마이페이지 아이디 조회 컨트롤러", description = "마이페이지 아이디 조회를 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @GetMapping("/my-page/get-userId")
     public ResponseTemplate<String> getUserId(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO) {
         String userId = memberPrincipalDTO.getUserId();
@@ -33,6 +44,10 @@ public class MemberController {
         return new ResponseTemplate<>(HttpStatus.OK, "회원 아이디 조회 성공", userId);
     }
 
+    @Operation(summary = "마이페이지 목표 단어 개수 조회 컨트롤러", description = "마이페이지 목표 단어 개수 조회를 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @GetMapping("/my-page/get-word-count")
     public ResponseTemplate<Integer> getWordCount(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO) {
         String userId = memberPrincipalDTO.getUserId();
@@ -40,6 +55,10 @@ public class MemberController {
         return new ResponseTemplate<>(HttpStatus.OK, "회원 목표 단어 개수 조회 성공", wordCount);
     }
 
+    @Operation(summary = "마이페이지 회원 정보 수정 컨트롤러", description = "마이페이지 회원 정보 수정을 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/my-page/edit-info")
     public ResponseTemplate<?> editMemberInfo(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO,
                                               @RequestBody MemberInfoDTO memberInfoDTO) {
@@ -49,6 +68,10 @@ public class MemberController {
         return new ResponseTemplate<>(HttpStatus.OK, "회원정보 수정 성공");
     }
 
+    @Operation(summary = "마이페이지 목표 단어 개수 수정 컨트롤러", description = "마이페이지 목표 단어 개수 수정을 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/my-page/edit-word-count")
     public ResponseTemplate<Integer> editWordCount(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO,
                                                    @RequestBody WordCountDTO wordCountDTO) {

--- a/src/main/java/com/se/dandan/controller/WordController.java
+++ b/src/main/java/com/se/dandan/controller/WordController.java
@@ -5,6 +5,9 @@ import com.se.dandan.dto.common.ResponseTemplate;
 import com.se.dandan.entity.Word;
 import com.se.dandan.service.ExampleService;
 import com.se.dandan.service.WordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -23,6 +26,10 @@ public class WordController {
         this.exampleService = exampleService;
     }
 
+    @Operation(summary = "단어 학습 컨트롤러", description = "학습할 단어들을 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @GetMapping("/today")
     public ResponseTemplate<List<Word>> getTodayWords(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO) {
         Long memberId = memberPrincipalDTO.getId();
@@ -32,6 +39,10 @@ public class WordController {
         return new ResponseTemplate<>(HttpStatus.OK, "단어 조회 성공", words);
     }
 
+    @Operation(summary = "AI 예문 생성 컨트롤러", description = "AI 예문 생성을 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/{wordId}/example")
     public ResponseTemplate<String> generateExample(@PathVariable Long wordId) {
         Word word = wordService.findById(wordId);
@@ -39,6 +50,10 @@ public class WordController {
         return new ResponseTemplate<>(HttpStatus.OK, "예문 조회 성공", example);
     }
 
+    @Operation(summary = "단어 진도율 확인 컨트롤러", description = "단어 진도율 확인을 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/{wordId}/memorized")
     public ResponseTemplate<Void> markAsMemorized(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO, @PathVariable Long wordId) {
         Long memberId = memberPrincipalDTO.getId();

--- a/src/main/java/com/se/dandan/controller/WordController.java
+++ b/src/main/java/com/se/dandan/controller/WordController.java
@@ -1,0 +1,48 @@
+package com.se.dandan.controller;
+
+import com.se.dandan.dto.MemberPrincipalDTO;
+import com.se.dandan.dto.common.ResponseTemplate;
+import com.se.dandan.entity.Word;
+import com.se.dandan.service.ExampleService;
+import com.se.dandan.service.WordService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/words")
+public class WordController {
+
+    private final WordService wordService;
+    private final ExampleService exampleService;
+
+    public WordController(WordService wordService,  ExampleService exampleService) {
+        this.wordService = wordService;
+        this.exampleService = exampleService;
+    }
+
+    @GetMapping("/today")
+    public ResponseTemplate<List<Word>> getTodayWords(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO) {
+        Long memberId = memberPrincipalDTO.getId();
+
+        List<Word> words = wordService.getTodayWords(memberId);
+
+        return new ResponseTemplate<>(HttpStatus.OK, "단어 조회 성공", words);
+    }
+
+    @PostMapping("/{wordId}/example")
+    public ResponseTemplate<String> generateExample(@PathVariable Long wordId) {
+        Word word = wordService.findById(wordId);
+        String example = exampleService.generateExample(word.getEnglish(), List.of(word.getMeaning1(), word.getMeaning2(), word.getMeaning3()));
+        return new ResponseTemplate<>(HttpStatus.OK, "예문 조회 성공", example);
+    }
+
+    @PostMapping("/{wordId}/memorized")
+    public ResponseTemplate<Void> markAsMemorized(@AuthenticationPrincipal MemberPrincipalDTO memberPrincipalDTO, @PathVariable Long wordId) {
+        Long memberId = memberPrincipalDTO.getId();
+        wordService.markedMemorized(memberId, wordId);
+        return new ResponseTemplate<>(HttpStatus.OK, "학습 완료");
+    }
+}

--- a/src/main/java/com/se/dandan/dto/MemberInfoDTO.java
+++ b/src/main/java/com/se/dandan/dto/MemberInfoDTO.java
@@ -1,13 +1,17 @@
 package com.se.dandan.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
+@Schema(description = "사용자 마이페이지 정보 DTO")
 @Data
 @Builder
 public class MemberInfoDTO {
 
+    @Schema(description = "사용자 닉네임")
     private String nickname;
 
+    @Schema(description = "사용자 비밀번호")
     private String password;
 }

--- a/src/main/java/com/se/dandan/dto/MemberPrincipalDTO.java
+++ b/src/main/java/com/se/dandan/dto/MemberPrincipalDTO.java
@@ -17,4 +17,7 @@ public class MemberPrincipalDTO {
 
     @Schema(description = "사용자 아이디")
     private String userId;
+
+    @Schema(description = "목표 단어 개수")
+    private int wordCount;
 }

--- a/src/main/java/com/se/dandan/dto/WordCountDTO.java
+++ b/src/main/java/com/se/dandan/dto/WordCountDTO.java
@@ -1,9 +1,12 @@
 package com.se.dandan.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+@Schema(description = "목표 단어 개수 DTO")
 @Data
 public class WordCountDTO {
 
+    @Schema(description = "목표 단어 개수")
     private int wordCount;
 }

--- a/src/main/java/com/se/dandan/entity/Word.java
+++ b/src/main/java/com/se/dandan/entity/Word.java
@@ -1,0 +1,28 @@
+package com.se.dandan.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Word {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String english;
+
+    private String meaning1;
+
+    private String meaning2;
+
+    private String meaning3;
+}

--- a/src/main/java/com/se/dandan/entity/WordBook.java
+++ b/src/main/java/com/se/dandan/entity/WordBook.java
@@ -1,0 +1,26 @@
+package com.se.dandan.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WordBook {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Word word;
+
+    private boolean isMemorized;
+    private boolean isTested;
+}

--- a/src/main/java/com/se/dandan/exception/ErrorCode.java
+++ b/src/main/java/com/se/dandan/exception/ErrorCode.java
@@ -16,6 +16,10 @@ public enum ErrorCode {
     NOT_MATCHED_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다"),
     SIGN_IN_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 잘못되었습니다."),
 
+    // 단어장 관련
+    WORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 단어가 존재하지 않습니다."),
+    WORDBOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 단어 학습 정보가 없습니다."),
+
     // 서버 에러
     DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러"),
 

--- a/src/main/java/com/se/dandan/repository/MemberRepository.java
+++ b/src/main/java/com/se/dandan/repository/MemberRepository.java
@@ -1,14 +1,16 @@
 package com.se.dandan.repository;
 
 import com.se.dandan.entity.Member;
+import jakarta.validation.constraints.NotNull;
+import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Member findByNickname(String nickname);
-
     Optional<Member> findByUserId(String userId);
 
     boolean existsByUserId(String userId);
+
+    Optional<Member> findById(@NonNull Long memberId);
 }

--- a/src/main/java/com/se/dandan/repository/WordBookRepository.java
+++ b/src/main/java/com/se/dandan/repository/WordBookRepository.java
@@ -1,0 +1,19 @@
+package com.se.dandan.repository;
+
+import com.se.dandan.entity.WordBook;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface WordBookRepository extends JpaRepository<WordBook, Long> {
+
+    List<WordBook> findByMemberId(Long memberId);
+
+    @Query(value = "SELECT * FROM member_word mw " +
+            "WHERE mw.member_id = :memberId " +
+            "LIMIT :limit", nativeQuery = true)
+
+    List<WordBook> findTodayWords(@Param("memberId") Long memberId, @Param("limit") int limit);
+}

--- a/src/main/java/com/se/dandan/repository/WordRepository.java
+++ b/src/main/java/com/se/dandan/repository/WordRepository.java
@@ -1,0 +1,18 @@
+package com.se.dandan.repository;
+
+import com.se.dandan.entity.Word;
+import lombok.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WordRepository extends JpaRepository<Word, Long> {
+    @Query(value = "SELECT * FROM Word ORDER BY RANDOM() LIMIT :count", nativeQuery = true)
+
+    List<Word> findRandomWords(@Param("count") int count);
+
+    Optional<Word> findById(@NonNull Long wordId);
+}

--- a/src/main/java/com/se/dandan/service/ExampleService.java
+++ b/src/main/java/com/se/dandan/service/ExampleService.java
@@ -1,0 +1,38 @@
+package com.se.dandan.service;
+
+import lombok.Data;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class ExampleService {
+
+    private final WebClient webClient = WebClient.builder()
+            .baseUrl("http://localhost:8000")
+            .build();
+
+    public String generateExample(String word, List<String> meaning) {
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("word", word);
+        requestBody.put("meaning", meaning);
+
+        return webClient.post()
+                .uri("/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(ExampleResponse.class)
+                .block()
+                .getAnswer();
+    }
+
+    @Data
+    static class ExampleResponse {
+        private String answer;
+    }
+}

--- a/src/main/java/com/se/dandan/service/WordService.java
+++ b/src/main/java/com/se/dandan/service/WordService.java
@@ -1,0 +1,67 @@
+package com.se.dandan.service;
+
+import com.se.dandan.entity.Member;
+import com.se.dandan.entity.Word;
+import com.se.dandan.entity.WordBook;
+import com.se.dandan.exception.CustomException;
+import com.se.dandan.exception.ErrorCode;
+import com.se.dandan.repository.MemberRepository;
+import com.se.dandan.repository.WordBookRepository;
+import com.se.dandan.repository.WordRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class WordService {
+
+    private final WordRepository wordRepository;
+
+    private final MemberRepository memberRepository;
+
+    private final WordBookRepository wordBookRepository;
+
+    public WordService(WordRepository wordRepository, MemberRepository memberRepository,  WordBookRepository wordBookRepository) {
+        this.wordRepository = wordRepository;
+        this.memberRepository = memberRepository;
+        this.wordBookRepository = wordBookRepository;
+    }
+
+    public List<Word> getTodayWords(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        int wordCount = member.getWordCount();
+
+        List<Word> allWords = wordRepository.findAll();
+        Collections.shuffle(allWords);
+        List<Word> words = allWords.stream().limit(wordCount).toList();
+
+        words.forEach(word -> {
+            wordBookRepository.save(WordBook.builder()
+                            .member(member)
+                            .word(word)
+                            .isMemorized(false)
+                            .isTested(false)
+                    .build());
+        });
+
+        return words;
+    }
+
+    public Word findById(Long id) {
+        Word word = wordRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.WORD_NOT_FOUND));
+
+        return word;
+    }
+
+    public void markedMemorized(Long memberId, Long wordId) {
+        WordBook wordBook = wordBookRepository.findByMemberId(memberId).stream()
+                .filter(w -> w.getWord().getId().equals(wordId))
+                .findFirst().orElseThrow(() -> new CustomException(ErrorCode.WORDBOOK_NOT_FOUND));
+
+        wordBook.setMemorized(true);
+        wordBookRepository.save(wordBook);
+    }
+}

--- a/src/main/java/com/se/dandan/util/JWTProvider.java
+++ b/src/main/java/com/se/dandan/util/JWTProvider.java
@@ -122,6 +122,7 @@ public class JWTProvider {
                 .id(member.getId())
                 .nickname(member.getNickname())
                 .userId(member.getUserId())
+                .wordCount(member.getWordCount())
                 .build();
 
         return new UsernamePasswordAuthenticationToken(memberPrincipalDTO, token, authorities);


### PR DESCRIPTION
## 📌 개요
- DANDAN의 단어 학습 기능 및 AI 예문 생성 기능을 구현하였습니다.
## 🚀 관련 이슈
- 관련된 이슈 번호: #10 

## ✅ 변경 사항
- 단어 학습 기능 구현
- AI 예문 생성 기능 구현

## 📝 상세 내용
- http://localhost:8080/api/v1/words/today 경로로 접속 시 사용자의 목표 단어 개수만큼 DB에 저장되어 있는 단어가 무작위로 보여집니다.
- http://localhost:8080/api/v1/words/{wordId}/memorized 경로로 접속 시 해당 단어를 사용자가 공부했음을 표시합니다. 인터페이스상, 다음 버튼을 클릭했을 시, 해당 요청과 다음 단어가 올 수 있도록 해야합니다.
  - 예시) 단어의 PK 값이 1일 경우,  http://localhost:8080/api/v1/words/1/memorized로 요청
- http://localhost:8080/api/v1/words/{wordId}/example 경로로 접속 시 해당 단어의 AI 예문 생성을 요청하고, 이에 대한 응답을 받습니다.
  - 예시) 단어의 PK 값이 1일 경우,  http://localhost:8080/api/v1/words/1/example로 요청

## 📸 스크린샷
- 단어 조회 성공 예시
![image](https://github.com/user-attachments/assets/0f57ce0a-93e6-411b-a98f-e8b8a6fc7505)

- 예문 생성 성공 예시
![image](https://github.com/user-attachments/assets/e23e6cdf-20e9-4a42-9259-e26dfc7a733c)