### PR TITLE
[Feature] 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/se/dandan/config/SecurityConfig.java
+++ b/src/main/java/com/se/dandan/config/SecurityConfig.java
@@ -1,8 +1,6 @@
 package com.se.dandan.config;
 
 import com.se.dandan.filter.JWTAuthenticationFilter;
-import com.se.dandan.service.TokenBlacklistService;
-import com.se.dandan.util.JWTProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -14,6 +12,11 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -67,5 +70,18 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return webSecurity -> webSecurity.ignoring()
                 .requestMatchers("/swagger-ui/**", "/favicon.ico", "/api-docs/**", "/v3/api-docs/**");
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000")); // 로컬 환경에서 CORS 허용
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/com/se/dandan/config/SecurityConfig.java
+++ b/src/main/java/com/se/dandan/config/SecurityConfig.java
@@ -1,8 +1,8 @@
 package com.se.dandan.config;
 
 import com.se.dandan.filter.JWTAuthenticationFilter;
+import com.se.dandan.service.TokenBlacklistService;
 import com.se.dandan.util.JWTProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -19,10 +19,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final JWTProvider jwtProvider;
+    private final JWTAuthenticationFilter jwtAuthenticationFilter;
 
-    public SecurityConfig(JWTProvider jwtProvider) {
-        this.jwtProvider = jwtProvider;
+    public SecurityConfig(JWTAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
     }
 
     @Bean
@@ -58,7 +58,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)); // 세션 비활성화
 
         http
-                .addFilterBefore(new JWTAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/se/dandan/controller/AuthController.java
+++ b/src/main/java/com/se/dandan/controller/AuthController.java
@@ -13,10 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Auth API", description = "회원가입 및 로그인 API")
 @RestController
@@ -58,5 +55,16 @@ public class AuthController {
         TokenInfo token = authService.signIn(signInRequestDTO, response);
 
         return new ResponseTemplate<>(HttpStatus.OK, "로그인 성공", token);
+    }
+
+    @Operation(summary = "로그아웃 컨트롤러", description = "로그아웃을 요청하는 컨트롤러 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
+    @PostMapping("/sign-out")
+    public ResponseTemplate<Void> logout(@RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring(7);
+        authService.signOut(token);
+        return new ResponseTemplate<>(HttpStatus.OK, "로그아웃 성공");
     }
 }

--- a/src/main/java/com/se/dandan/entity/BlacklistedToken.java
+++ b/src/main/java/com/se/dandan/entity/BlacklistedToken.java
@@ -22,9 +22,7 @@ public class BlacklistedToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String refreshToken;
-
-    private String userId;
+    private String token;
 
     private LocalDateTime expiration;
 }

--- a/src/main/java/com/se/dandan/entity/BlacklistedToken.java
+++ b/src/main/java/com/se/dandan/entity/BlacklistedToken.java
@@ -1,0 +1,30 @@
+package com.se.dandan.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BlacklistedToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String refreshToken;
+
+    private String userId;
+
+    private LocalDateTime expiration;
+}

--- a/src/main/java/com/se/dandan/exception/ErrorCode.java
+++ b/src/main/java/com/se/dandan/exception/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
     NOT_MATCHED_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다"),
     SIGN_IN_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 잘못되었습니다."),
 
+    // 로그아웃 관련
+    ALREADY_SIGN_OUT(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰 입니다."),
+
     // 단어장 관련
     WORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 단어가 존재하지 않습니다."),
     WORDBOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 단어 학습 정보가 없습니다."),

--- a/src/main/java/com/se/dandan/filter/JWTAuthenticationFilter.java
+++ b/src/main/java/com/se/dandan/filter/JWTAuthenticationFilter.java
@@ -1,5 +1,9 @@
 package com.se.dandan.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.se.dandan.exception.ErrorCode;
+import com.se.dandan.exception.ErrorResponse;
+import com.se.dandan.service.TokenBlacklistService;
 import com.se.dandan.util.JWTProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -7,11 +11,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import javax.swing.undo.CannotUndoException;
 import java.io.IOException;
 
 @Slf4j
@@ -20,12 +26,24 @@ import java.io.IOException;
 public class JWTAuthenticationFilter extends OncePerRequestFilter {
 
     private final JWTProvider jwtProvider;
+    private final TokenBlacklistService tokenBlacklistService;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = resolveToken(request);
 
         if (token != null && jwtProvider.validateToken(token)) {
+            if(tokenBlacklistService.isBlacklisted(token)) {
+
+                ErrorCode errorCode = ErrorCode.ALREADY_SIGN_OUT;
+                ErrorResponse errorResponse = new ErrorResponse(errorCode);
+
+                response.setStatus(errorResponse.getStatus());
+                response.setContentType("application/json;charset=UTF-8");
+                response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+                return;
+            }
             Authentication auth = jwtProvider.getAuthentication(token); // 사용자 추출
             SecurityContextHolder.getContext().setAuthentication(auth); // SecurityContextHolder에 사용자 등록
         }

--- a/src/main/java/com/se/dandan/repository/BlacklistedTokenRepository.java
+++ b/src/main/java/com/se/dandan/repository/BlacklistedTokenRepository.java
@@ -1,0 +1,8 @@
+package com.se.dandan.repository;
+
+import com.se.dandan.entity.BlacklistedToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlacklistedTokenRepository extends JpaRepository<BlacklistedToken, Long> {
+    boolean existsByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/se/dandan/repository/BlacklistedTokenRepository.java
+++ b/src/main/java/com/se/dandan/repository/BlacklistedTokenRepository.java
@@ -3,6 +3,9 @@ package com.se.dandan.repository;
 import com.se.dandan.entity.BlacklistedToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+
 public interface BlacklistedTokenRepository extends JpaRepository<BlacklistedToken, Long> {
-    boolean existsByRefreshToken(String refreshToken);
+    boolean existsByToken(String token);
+    void deleteAllByExpirationBefore(LocalDateTime time);
 }

--- a/src/main/java/com/se/dandan/service/AuthService.java
+++ b/src/main/java/com/se/dandan/service/AuthService.java
@@ -22,15 +22,18 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final JWTProvider jwtProvider;
-    private final int refreshedMS;
+    private final TokenBlacklistService tokenBlacklistService;
+    private final long refreshedMS;
 
     public AuthService(MemberRepository memberRepository,
                        BCryptPasswordEncoder bCryptPasswordEncoder,
                        JWTProvider jwtProvider,
-                       @Value("${jwt.refreshedMs}") int refreshedMS) {
+                       TokenBlacklistService tokenBlacklistService,
+                       @Value("${jwt.refreshedMs}") long refreshedMS) {
         this.memberRepository = memberRepository;
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
         this.jwtProvider = jwtProvider;
+        this.tokenBlacklistService = tokenBlacklistService;
         this.refreshedMS = refreshedMS;
     }
 
@@ -100,7 +103,7 @@ public class AuthService {
 
     private Cookie createCookie(String value) {
         Cookie cookie = new Cookie("Refresh", value);
-        cookie.setMaxAge(refreshedMS / 1000);
+        cookie.setMaxAge((int)refreshedMS / 1000);
         cookie.setSecure(true);
         cookie.setHttpOnly(true);
 

--- a/src/main/java/com/se/dandan/service/AuthService.java
+++ b/src/main/java/com/se/dandan/service/AuthService.java
@@ -109,4 +109,9 @@ public class AuthService {
 
         return cookie;
     }
+
+    public void signOut(String token) {
+        long expiration = jwtProvider.getExpiration(token);
+        tokenBlacklistService.blacklistToken(token,  expiration);
+    }
 }

--- a/src/main/java/com/se/dandan/service/TokenBlacklistService.java
+++ b/src/main/java/com/se/dandan/service/TokenBlacklistService.java
@@ -1,0 +1,38 @@
+package com.se.dandan.service;
+
+import com.se.dandan.entity.BlacklistedToken;
+import com.se.dandan.repository.BlacklistedTokenRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.*;
+
+@Service
+public class TokenBlacklistService {
+
+    private final BlacklistedTokenRepository blacklistedTokenRepository;
+
+    public TokenBlacklistService(BlacklistedTokenRepository blacklistedTokenRepository) {
+        this.blacklistedTokenRepository = blacklistedTokenRepository;
+    }
+
+    public void blacklistToken(String token, long expiration) {
+        LocalDateTime expirationTime = LocalDateTime.now().plus(Duration.ofMillis(expiration));
+        BlacklistedToken blacklistedToken = new BlacklistedToken();
+        blacklistedToken.setToken(token);
+        blacklistedToken.setExpiration(expirationTime);
+        blacklistedTokenRepository.save(blacklistedToken);
+    }
+
+    public boolean isBlacklisted(String token) {
+        return blacklistedTokenRepository.existsByToken(token);
+    }
+
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional
+    public void cleanExpiredTokens() {
+        LocalDateTime now = LocalDateTime.now();
+        blacklistedTokenRepository.deleteAllByExpirationBefore(now);
+    }
+}

--- a/src/main/java/com/se/dandan/util/JWTProvider.java
+++ b/src/main/java/com/se/dandan/util/JWTProvider.java
@@ -19,6 +19,8 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -126,5 +128,17 @@ public class JWTProvider {
                 .build();
 
         return new UsernamePasswordAuthenticationToken(memberPrincipalDTO, token, authorities);
+    }
+
+    public long getExpiration(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        Date expiration = claims.getExpiration();
+
+        return expiration.getTime() - System.currentTimeMillis();
     }
 }


### PR DESCRIPTION
## 📌 개요
- DANDAN의 로그아웃 기능 구현을 완료하였습니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #13 

## ✅ 변경 사항
- 로그아웃 기능 추가
- 로그아웃 API Swagger 테스트 방법
로그인 API (/api/v1/auth/sign-in) 호출 → Access Token 발급
상단 Authorize 버튼 클릭 → 발급 받은 Access Token 넣기
로그아웃 API (/api/v1/auth/sign-out) 테스트 → 발급 받은 Access Token 넣기

## 📝 상세 내용
### 로그아웃 API 구현
- POST /api/v1/auth/sign-out 엔드포인트 추가
- Authorization 헤더에서 Access Token을 추출하여 로그아웃 처리
- Access Token을 token_blacklist 테이블에 저장하여 재사용 차단
### JWT 인증 필터 수정
- JwtAuthenticationFilter에 블랙리스트 확인 로직 추가
- 블랙리스트에 등록된 토큰으로 접근 시 401 Unauthorized + "이미 로그아웃된 토큰입니다." 반환
- 스케줄러 설정
만료된 블랙리스트 토큰을 매시 정각마다 주기적으로 삭제하는 @Scheduled 메서드 추가
